### PR TITLE
Admin content now hidden from public; add logout

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -14,6 +14,7 @@ class App extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
+      isModerator: false,
       tipsTestCity: 'san francisco',
       tipsTestState: 'California',
       photoUrl: [],
@@ -52,16 +53,6 @@ class App extends React.Component {
       });
   }
 
-  // logout() {
-  //   axios.get('/logout')
-  //     .then((result) => {
-  //       // console.log(result);
-  //     })
-  //     .catch((err) => {
-  //       // console.log(err);
-  //     });
-  // }
-
   getTopTweetsFrom(lat, lon) {
     this.setState({topTweetsFrom: ''});
     axios.get('/topTweetsFrom', {params: {lat: lat, lon: lon}})
@@ -87,11 +78,6 @@ class App extends React.Component {
       oldTweetsFrom: '',
       oldTweetsAbout: ''
     });
-
-    // this.state.recentTweetsFrom = '';
-    // this.state.recentTweetsAbout = '';
-    // this.state.oldTweetsFrom = '';
-    // this.state.oldTweetsAbout = '';
 
     axios.get('/recentTweetsFrom', {params: {lat: lat, lon: lon}})
       .then((results) => {
@@ -119,7 +105,6 @@ class App extends React.Component {
   }
 
   getPhoto(lat, lon) {
-
     axios.get('/googlepics', {params: {lat: lat, lon: lon}})
       .then ((result) => {
         //TODO: CHANGE THIS BACK LATER! PHOTO IS HARDCODED
@@ -169,67 +154,11 @@ class App extends React.Component {
     this.setState({
       mapLoading: false
     });
-
-    /*** LONG NASTY CODE TO GET USER'S LOCATION AS INIT VALUES,
-    if you want to enable this, must comment out the top codes
-      and uncomment everything bellow ***/
-
-    //get the user's location, and set lat and lng to be that
-    //if they decline, set sf to be the main.
-
-    //HTML5 geolocation.
-    // if (navigator.geolocation) {
-    //   navigator.geolocation.getCurrentPosition(function(position) {
-    //     console.log('User allowed access to their location');
-
-    //     var pos = {
-    //       lat: position.coords.latitude,
-    //       lng: position.coords.longitude
-    //     };
-
-    //     //get the photo and walkability of the address of user
-    //     this.getPhoto(pos.lat, pos.lng);
-    //     this.getWalkability(pos.lat, pos.lng);
-
-    //     //need to get the city/state associated with the lat/lon
-    //     var geocoder = new google.maps.Geocoder;
-    //     geocoder.geocode({'location': pos }, function(results, status) {
-    //       if (status === 'OK') {
-    //         console.log('MY ADDRESS : ', results);
-    //         var result = this.getCityState(results);
-    //         var state = result[1];
-    //         var city = result[0];
-
-    //         //check if it has a city/state? if not valid, default to sf?
-    //         this.setState({
-    //           lat: position.coords.latitude,
-    //           lng: position.coords.longitude,
-    //           city: city,
-    //           state: state,
-    //           mapLoading: false
-    //         });
-    //       } else {
-    //         console.log('could not acquire user address from lat/long');
-    //       }
-    //     }.bind(this));
-    //   }.bind(this), function(err) {
-    //     console.log('User did not allow access to their location');
-    //     this.setState({
-    //       mapLoading: false
-    //     });
-    //     this.getPhoto(this.state.lat, this.state.lng);
-    //     this.getWalkability(this.state.lat, this.state.lng);
-
-    //   }.bind(this));
-    // }
-    // else {
-    //   //browser doesn't have HTML5 geolocation
-    //   this.setState({
-    //       mapLoading: false
-    //   });
-    //   this.getPhoto(this.state.lat, this.state.lng);
-    //   this.getWalkability(this.state.lat, this.state.lng);
-    // }
+    axios.get('/lalaAdmin')
+      .then((response) => {
+        this.setState({ isModerator: response.data});
+      })
+      .catch(err => console.log(err));
   }
 
   //The Map component calls this function with the updated values
@@ -367,11 +296,22 @@ class App extends React.Component {
       );
     }
     if (this.props.view === 'admin') {
-      return (
-        <div className="row">
-          <AdminPanel />
-        </div>
-      );
+      console.log('admin status ', this.state.isModerator);
+      if (this.state.isModerator) {
+        return (
+          <div className="row">
+            <AdminPanel />
+          </div>
+        );
+      } else {
+        return (
+          <div className="row">
+            <p className="center">Unauthorized.
+              <br />Please log in as an administrative user by clicking the Facebook button above.
+            </p>
+          </div>
+        );
+      }
     }
   }
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -154,11 +154,6 @@ class App extends React.Component {
     this.setState({
       mapLoading: false
     });
-    axios.get('/lalaAdmin')
-      .then((response) => {
-        this.setState({ isModerator: response.data});
-      })
-      .catch(err => console.log(err));
   }
 
   //The Map component calls this function with the updated values
@@ -295,9 +290,9 @@ class App extends React.Component {
         </div>
       );
     }
-    if (this.props.view === 'admin') {
-      console.log('admin status ', this.state.isModerator);
-      if (this.state.isModerator) {
+    if (this.props.view === 'moderator') {
+      console.log('admin status ', this.props.isModerator);
+      if (this.props.isModerator) {
         return (
           <div className="row">
             <AdminPanel />
@@ -312,6 +307,13 @@ class App extends React.Component {
           </div>
         );
       }
+    }
+    if (this.props.view === 'loggedOut') {
+      return (
+        <div className="row">
+          <p className="center">You are now logged out.</p>
+        </div>
+      );
     }
   }
 }

--- a/client/src/Index.jsx
+++ b/client/src/Index.jsx
@@ -40,7 +40,6 @@ class Index extends React.Component {
               <button type="button" className="nav-item btn btn-primary btn-outline-success my-2 my-sm-0 nav-btn admin-btn" onClick={ () => this.logout() }>Logout</button>
             </div>
             <button type="button" className="nav-item btn btn-primary btn-outline-success my-2 my-sm-0 nav-btn admin-btn pull-right" onClick={() => { this.changeView('admin'); }}>Admin</button>
-            <button type="button" className="nav-item btn btn-primary btn-outline-success my-2 my-sm-0 nav-btn admin-btn pull-right" onClick={ () => this.admin() }>Test</button>
           </div>
         </nav>
         <div className="row">

--- a/client/src/Index.jsx
+++ b/client/src/Index.jsx
@@ -6,10 +6,12 @@ class Index extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      view: 'home'
+      view: 'home',
+      isModerator: false
     };
     this.changeView = this.changeView.bind(this);
     this.renderView = this.renderView.bind(this);
+    this.logout = this.logout.bind(this);
   }
 
   changeView(view) {
@@ -19,7 +21,21 @@ class Index extends React.Component {
   }
 
   renderView() {
-    return ( <App view={this.state.view} /> );
+    return ( <App isModerator={this.state.isModerator} view={this.state.view} /> );
+  }
+
+  logout() {
+    axios.get('/logout');
+    this.setState({ isModerator: false });
+    this.changeView('loggedOut');
+  }
+
+  componentWillMount() {
+    axios.get('/moderator')
+      .then((response) => {
+        this.setState({ isModerator: response.data});
+      })
+      .catch(err => console.log(err));
   }
 
   render() {
@@ -37,9 +53,9 @@ class Index extends React.Component {
             <button type="button" className="nav-item btn btn-primary btn-outline-success my-2 my-sm-0 nav-btn" onClick={() => { this.changeView('compare'); }}>Compare</button>
             <div className="btn-group-vertical pull-right">
               <a href="/auth/facebook" className="nav-item btn btn-primary btn-outline-success my-2 my-sm-0 nav-btn admin-btn"><span className="fa fa-facebook"></span>Facebook</a>
-              <button type="button" className="nav-item btn btn-primary btn-outline-success my-2 my-sm-0 nav-btn admin-btn" onClick={ () => this.logout() }>Logout</button>
+              <button type="button" className="nav-item btn btn-primary btn-outline-success my-2 my-sm-0 nav-btn admin-btn" onClick={ this.logout }>Logout</button>
             </div>
-            <button type="button" className="nav-item btn btn-primary btn-outline-success my-2 my-sm-0 nav-btn admin-btn pull-right" onClick={() => { this.changeView('admin'); }}>Admin</button>
+            <button type="button" className="nav-item btn btn-primary btn-outline-success my-2 my-sm-0 nav-btn admin-btn pull-right" onClick={() => { this.changeView('moderator'); }}>Moderator</button>
           </div>
         </nav>
         <div className="row">

--- a/client/src/loggedin/AdminPanel.jsx
+++ b/client/src/loggedin/AdminPanel.jsx
@@ -77,7 +77,6 @@ class AdminPanel extends React.Component {
     return (
       <div>
         <h1 className="center">Moderate Tips</h1>
-        <h3 className="center">All Submitted Tips</h3>
         <p className="center filter-tips">You have {this.state.flaggedTipsCount} flagged tips. View:
           <select onChange={(e) => this.filterTips(e.target.value)}>
             <option value="all">All</option>

--- a/server/index.js
+++ b/server/index.js
@@ -75,11 +75,12 @@ app.get('/auth/facebook/callback',
 
 app.get('/lalaAdmin', (req, res) => {
   if (req.user) {
-    console.log(req);
+    console.log(req.user);
+    res.send(req.user.admin);
   } else {
-    console.log('it is undefined?');
+    console.log('no user is logged in');
+    res.send();
   }
-  res.send();
 });
 
 app.get('/logout', function (req, res) {

--- a/server/index.js
+++ b/server/index.js
@@ -73,9 +73,8 @@ app.get('/auth/facebook/callback',
   }
 );
 
-app.get('/lalaAdmin', (req, res) => {
+app.get('/moderator', (req, res) => {
   if (req.user) {
-    console.log(req.user);
     res.send(req.user.admin);
   } else {
     console.log('no user is logged in');
@@ -88,7 +87,6 @@ app.get('/logout', function (req, res) {
     if (err) {
       return next(err);
     }
-    
     req.logout();
 
     res.redirect('/');


### PR DESCRIPTION
The facebook user ids are used to identify moderators in the db.

Logout button now kills session, renders a logout page.

Moderators can access the admin panel only if logged in.